### PR TITLE
docs: fix simple typo, unpredicatable -> unpredictable

### DIFF
--- a/depends_linux/include/mysqlclient/my_sys.h
+++ b/depends_linux/include/mysqlclient/my_sys.h
@@ -424,7 +424,7 @@ typedef struct st_io_cache		/* Used when cacheing files */
   int (*write_function)(struct st_io_cache *,const uchar *,size_t);
   /*
     Specifies the type of the cache. Depending on the type of the cache
-    certain operations might not be available and yield unpredicatable
+    certain operations might not be available and yield unpredictable
     results. Details to be documented later
   */
   enum cache_type type;

--- a/depends_mac/include/mysqlclient/my_sys.h
+++ b/depends_mac/include/mysqlclient/my_sys.h
@@ -424,7 +424,7 @@ typedef struct st_io_cache		/* Used when cacheing files */
   int (*write_function)(struct st_io_cache *,const uchar *,size_t);
   /*
     Specifies the type of the cache. Depending on the type of the cache
-    certain operations might not be available and yield unpredicatable
+    certain operations might not be available and yield unpredictable
     results. Details to be documented later
   */
   enum cache_type type;

--- a/depends_win/include/mysqlclient/my_sys.h
+++ b/depends_win/include/mysqlclient/my_sys.h
@@ -389,7 +389,7 @@ typedef struct st_io_cache		/* Used when cacheing files */
   int (*write_function)(struct st_io_cache *,const uchar *,size_t);
   /*
     Specifies the type of the cache. Depending on the type of the cache
-    certain operations might not be available and yield unpredicatable
+    certain operations might not be available and yield unpredictable
     results. Details to be documented later
   */
   enum cache_type type;


### PR DESCRIPTION
There is a small typo in depends_linux/include/mysqlclient/my_sys.h, depends_mac/include/mysqlclient/my_sys.h, depends_win/include/mysqlclient/my_sys.h.

Should read `unpredictable` rather than `unpredicatable`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md